### PR TITLE
Fic removal of / at path start for unix compatability

### DIFF
--- a/src/main/kotlin/icu/windea/pls/core/StdlibExtensions.kt
+++ b/src/main/kotlin/icu/windea/pls/core/StdlibExtensions.kt
@@ -570,7 +570,7 @@ fun String.normalizePath(): String {
     if(this.isEmpty()) return ""
     val builder = StringBuilder()
     var separatorFlag = false
-    this.trim('/', '\\').forEach { c ->
+    this.trimEnd('/', '\\').forEach { c ->
         if (c == '/' || c == '\\') {
             separatorFlag = true
         } else if (separatorFlag) {


### PR DESCRIPTION
On Unix systems absolute paths start with a /. So i always got an error trying to select my game folders.
I changed the trim to only remove slash and backslash from the end of the path. Tested the game folder selection successfully on Manjaro and Windows.