### PR TITLE
Add Preliminary Support for Linux and MacOS Paths

### DIFF
--- a/src/main/kotlin/icu/windea/pls/lang/PlsDataProvider.kt
+++ b/src/main/kotlin/icu/windea/pls/lang/PlsDataProvider.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.*
  */
 @Service
 class PlsDataProvider {
+    val OS: String = System.getProperty("os.name", "Windows")
     fun init() {
         //preload cached values
         initForPaths()
@@ -57,6 +58,7 @@ class PlsDataProvider {
     }
 
     private fun doGetSteamPath(): String {
+        if(!OS.contains("Windows")) return ""
         val command = """Get-ItemProperty -Path 'HKLM:\SOFTWARE\Wow6432Node\Valve\Steam' | Select-Object InstallPath | Format-Table -HideTableHeaders"""
         return runCatchingCancelable { executeCommand(command, CommandType.POWER_SHELL) }.getOrDefault("")
     }
@@ -72,6 +74,7 @@ class PlsDataProvider {
     }
 
     private fun doGetSteamGamePath(steamId: String): String {
+        if(!OS.contains("Windows")) return "";
         val command = """Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App ${steamId}' | Select-Object InstallLocation | Format-Table -HideTableHeaders"""
         return runCatchingCancelable { executeCommand(command, CommandType.POWER_SHELL) }.getOrDefault("")
     }
@@ -79,7 +82,9 @@ class PlsDataProvider {
     private fun doGetFallbackSteamGamePath(gameName: String): String? {
         //不准确，可以放在不同库目录下
         val steamPath = getSteamPath() ?: return null
-        return """$steamPath\steamapps\common\$gameName"""
+        var path = """$steamPath\steamapps\common\$gameName"""
+        if(!OS.contains("Windows")) path = path.replace("\\", "/");
+        return path
     }
 
     /**
@@ -88,7 +93,9 @@ class PlsDataProvider {
     fun getSteamWorkshopPath(steamId: String): String? {
         //不准确，可以放在不同库目录下
         val steamPath = getSteamPath() ?: return null
-        return """$steamPath\steamapps\workshop\content\$steamId"""
+        var path = """$steamPath\steamapps\workshop\content\$steamId"""
+        if(!OS.contains("Windows")) path = path.replace("\\", "/");
+        return path
     }
 
     /**
@@ -97,7 +104,10 @@ class PlsDataProvider {
     fun getGameDataPath(gameName: String): String? {
         //实际上应当基于launcher-settings.json中的gameDataPath
         val userHome = System.getProperty("user.home") ?: return null
-        return """$userHome\Documents\Paradox Interactive\$gameName"""
+        // Note: needs to be symlinked to install path.
+        var path = """$userHome\Documents\Paradox Interactive\$gameName"""
+        if(!OS.contains("Windows")) path = path.replace("\\", "/");
+        return path
     }
 
     //endregion


### PR DESCRIPTION
This is a very simple PR. I use Linux as my main OS, and found out that the `Mod Dependencies > Import From > Game` Option wouldn't work, as the plugin tried to access the User Data directory with reverse (Windows-style).

This PR fixes that by converting the paths to conform to the OS specifications when they are converted from a String to a Path/File object, using the now-implemented `[File|Path].toPlatformAgnostic()` extension.

If the **OS is Windows**, no changes are done.
If the **OS is not Windows**:
* Backward Slashes (`\`) are replaced with forward slashes (`/`)
* Drive Roots (like `Z:`) are removed. Those are used by Proton/Wine to emulate Windows paths (usually `Z:` maps to the actual UNIX system root).

This has been tested in my install (Arch Linux, Proton Experimental) but should work in any Linux/MacOS Distros.
If using Wine/Proton, you may want to symlink the Stellaris user data to the Documents folder (plus, this makes it easier to access it anyways) with:
```
cd ~/Documents
mkdir "Paradox Interactive"
ln -s "/home/{{ user }}/.steam/steam/steamapps/compatdata/281990/pfx/drive_c/users/steamuser/Documents/Paradox Interactive/Stellaris/" ~/Documents/Paradox Interactive/Stellaris
```

**I could not test if the Windows behaviour remains unaffected (as I don't have a Windows Install), but it should... theoretically. I would at least test the   `Mod Dependencies > Import From > Game`  feature before merging.** - if that works, so should the rest :P

Thank you for the great work with this plugin <3