### PR TITLE
fix hoi4's dlc content index

### DIFF
--- a/src/main/resources/data/game_type_metadata_list.json5
+++ b/src/main/resources/data/game_type_metadata_list.json5
@@ -86,7 +86,9 @@
   {
     "gameType": "hoi4",
     "gameMainEntries": [
-      ""
+      "",
+      "dlc/*",
+      "integrated_dlc/*",
     ],
     "gameExtraEntries": [
       "clausewitz",


### PR DESCRIPTION
add hoi4's dlc content index in `game_type_metadata_list.json5`